### PR TITLE
Add passthrough config for person card

### DIFF
--- a/assets/js/fsPerson/templates/fsPersonVitals.html
+++ b/assets/js/fsPerson/templates/fsPersonVitals.html
@@ -1,5 +1,5 @@
 <div class="fs-person-vitals">
-  <div data-fs-add-wrapper-if="person.id" title="{{title}}">
+  <div data-fs-add-wrapper-if="person.id" title="{{title}}" bindonce="person">
     <div class="fs-person-vitals__name" data-ng-class="nameConclusionStyle">
       <a data-bo-href="'#view=ancestor&person=' + person.id" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard" data-cmd="openPersonCard" data-cmd-data='{{openPersonCardData}}'>
         <span class="fs-person-vitals__name--split" data-bo-if="person.nameConclusion.details.nameForms">

--- a/assets/js/fsPerson/viewModels/fsPersonVitals.viewModel.js
+++ b/assets/js/fsPerson/viewModels/fsPersonVitals.viewModel.js
@@ -37,7 +37,8 @@ function fsPersonVitalsViewModel(scope) {
   scope.openPersonCardData = JSON.stringify({
     "id": scope.person.id,
     "name": scope.person.name,
-    "gender": scope.person.gender
+    "gender": scope.person.gender,
+    "linksInNewTab": scope.options.linksInNewTab
   });
 
   scope.lifeSpan = (scope.options.lifeSpan === 'long' ? scope.person.fullLifeSpan : scope.person.lifeSpan);


### PR DESCRIPTION
Allows all links on a person card to open in a new window/tab.
Make sure person is defined in vitals section before running bindonce.