### PR TITLE
BindOnce: Calculate genderClass before binding

### DIFF
--- a/assets/js/fsPerson/templates/fsPersonGender.html
+++ b/assets/js/fsPerson/templates/fsPersonGender.html
@@ -1,4 +1,4 @@
-<div class="fs-person-gender" bindonce="!!person && !!person.id || undefined">
+<div class="fs-person-gender" bindonce="!!person && !!person.id && !!genderClass || undefined">
   <div class="fs-person-gender__container" data-bo-class="genderClass">
     <div class="fs-person-gender__image fs-couple__connector" data-bo-class="genderImageClass"></div>
   </div>


### PR DESCRIPTION
The genderClass wasn't being calculated quickly enough for the BindOnce plugin, so the gender icon of a person in a child, spouse, or parent list in the pedigrees was not rendering.