### PR TITLE
Bug Fix: Firefox fsModules person-rendering NPE

### DIFF
--- a/assets/js/fsPerson/templates/fsPersonVitals.html
+++ b/assets/js/fsPerson/templates/fsPersonVitals.html
@@ -1,7 +1,7 @@
 <div class="fs-person-vitals">
-  <div data-fs-add-wrapper-if="person.id" title="{{title}}" bindonce="person">
-    <div class="fs-person-vitals__name" data-ng-class="nameConclusionStyle">
-      <a data-bo-href="'#view=ancestor&person=' + person.id" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard" data-cmd="openPersonCard" data-cmd-data='{{openPersonCardData}}'>
+  <div data-fs-add-wrapper-if="person.id" title="{{title}}">
+    <div class="fs-person-vitals__name" data-ng-class="nameConclusionStyle" bindonce="!!person && !!person.id || undefined">
+      <a data-ng-href="#view=ancestor&person={{person.id}}" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard" data-cmd="openPersonCard" data-cmd-data='{{openPersonCardData}}'>
         <span class="fs-person-vitals__name--split" data-bo-if="person.nameConclusion.details.nameForms">
           <span class="fs-person-vitals__name-given" data-bo-html="givenPart" data-test="given-name"></span><br>
           <span class="fs-person-vitals__name-family" data-bo-html="familyPart" data-test="family-name"></span>


### PR DESCRIPTION
fs-add-wrapper-if appeared to conflict with bo-href in Firefox, causing a JavaScript error--add check for node before attempting to set properties on it.
Add handler to remove unnecessary bindonce attributes.