### PR TITLE
Remove BindOnce to allow person card passthrough config to deploy

### DIFF
--- a/assets/js/fsPerson/templates/fsPersonGender.html
+++ b/assets/js/fsPerson/templates/fsPersonGender.html
@@ -1,6 +1,6 @@
-<div class="fs-person-gender" bindonce="!!person && !!person.id && !!genderClass || undefined">
-  <div class="fs-person-gender__container" data-bo-class="genderClass">
-    <div class="fs-person-gender__image fs-couple__connector" data-bo-class="genderImageClass"></div>
+<div class="fs-person-gender">
+  <div class="fs-person-gender__container" data-ng-class="genderClass">
+    <div class="fs-person-gender__image fs-couple__connector" data-ng-class="genderImageClass"></div>
   </div>
   <fs-person-vitals data-person="person" data-options="options"></fs-person-vitals>
 </div>

--- a/assets/js/fsPerson/templates/fsPersonPortrait.html
+++ b/assets/js/fsPerson/templates/fsPersonPortrait.html
@@ -1,7 +1,7 @@
-<div class="fs-person-portrait" bindonce="person">
+<div class="fs-person-portrait">
   <div class="fs-person-portrait__container">
     <div class="fs-person-portrait__portrait fs-couple__connector fs-icon-before fs-icon-large-{{gender}}">
-      <img class="fs-person-portrait__image" data-bo-if="person.portraitUrl" data-bo-src-i="{{person.portraitUrl}}" data-test="portrait">
+      <img class="fs-person-portrait__image" data-ng-if="person.portraitUrl" data-ng-src="{{person.portraitUrl}}" data-test="portrait">
     </div>
   </div>
   <div class="fs-person-portrait__gender-wrapper">

--- a/assets/js/fsPerson/templates/fsPersonVitals.html
+++ b/assets/js/fsPerson/templates/fsPersonVitals.html
@@ -1,26 +1,26 @@
 <div class="fs-person-vitals">
-  <div data-fs-add-wrapper-if="person.id" title="{{title}}" bindonce="person">
+  <div data-fs-add-wrapper-if="person.id" title="{{title}}">
     <div class="fs-person-vitals__name" data-ng-class="nameConclusionStyle">
-      <a data-bo-href="'#view=ancestor&person=' + person.id" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard" data-cmd="openPersonCard" data-cmd-data='{{openPersonCardData}}'>
-        <span class="fs-person-vitals__name--split" data-bo-if="person.nameConclusion.details.nameForms">
-          <span class="fs-person-vitals__name-given" data-bo-html="givenPart" data-test="given-name"></span><br>
-          <span class="fs-person-vitals__name-family" data-bo-html="familyPart" data-test="family-name"></span>
+      <a data-ng-href="'#view=ancestor&person=' + person.id" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard" data-cmd="openPersonCard" data-cmd-data='{{openPersonCardData}}'>
+        <span class="fs-person-vitals__name--split" data-ng-if="person.nameConclusion.details.nameForms">
+          <span class="fs-person-vitals__name-given" data-ng-bind-html="givenPart" data-test="given-name"></span><br>
+          <span class="fs-person-vitals__name-family" data-ng-bind-html="familyPart" data-test="family-name"></span>
         </span>
-        <span class="fs-person-vitals__name-full" data-bo-html="name" data-test="full-name"></span>
+        <span class="fs-person-vitals__name-full" data-ng-bind-html="name" data-test="full-name"></span>
       </a>
     </div>
     <div class="fs-person-vitals__fs-person-details">
-      <div class="fs-person-details__container" bindonce="!!person && !!lifeSpan || undefined">
-        <span class="fs-person-details__lifeSpan" data-bo-if="!options.hideLifeSpan && lifeSpan" data-bo-html="lifeSpan" data-test="lifeSpan"></span>
-        <span class="fs-person-details__separator" data-bo-if="showDot">&nbsp;•&nbsp;</span>
-        <span class="fs-person-details__id" data-bo-if="!options.hideId && person.id" data-bo-html="person.id" data-test="pid"></span>
+      <div class="fs-person-details__container">
+        <span class="fs-person-details__lifeSpan" data-ng-if="!options.hideLifeSpan && lifeSpan" data-ng-bind-html="lifeSpan" data-test="lifeSpan"></span>
+        <span class="fs-person-details__separator" data-ng-if="showDot">&nbsp;•&nbsp;</span>
+        <span class="fs-person-details__id" data-ng-if="!options.hideId && person.id" data-ng-bind-html="person.id" data-test="pid"></span>
         <span class="fs-person-details__selection-stopper">&#8203;</span>
       </div>
-      <span class="fs-person-details__birthPlace" data-bo-if="options.showBirthPlace && person.birthPlace" data-test="birthPlace" data-bo-html="person.birthPlace"></span>
+      <span class="fs-person-details__birthPlace" data-ng-if="options.showBirthPlace && person.birthPlace" data-test="birthPlace" data-ng-bind-html="person.birthPlace"></span>
     </div>
-    <div class="fs-person__fs-person-parents" data-bo-if="options.showParents">
-      <input id="fs-person-parents-{{uid}}" type="checkbox" class="fs-person-parents__show-button sr-only" data-bo-if="options.showParents && person.parents">
-      <label for="fs-person-parents-{{uid}}" class="fs-person-parents__show-label" data-bo-if="options.showParents && person.parents">
+    <div class="fs-person__fs-person-parents" data-ng-if="options.showParents">
+      <input id="fs-person-parents-{{uid}}" type="checkbox" class="fs-person-parents__show-button sr-only" data-ng-if="options.showParents && person.parents">
+      <label for="fs-person-parents-{{uid}}" class="fs-person-parents__show-label" data-ng-if="options.showParents && person.parents">
         <span class="fs-person-parents__show-text">{BUTTON_SHOW_PARENTS}</span>
         <span class="fs-person-parents__hide-text">{BUTTON_HIDE_PARENTS}</span>
       </label>


### PR DESCRIPTION
There is a lingering issue with BindOnce that causes person details on the person page to not update when the person changes when using this implementation. Tree needs to get the person card changes incorporated and released without BindOnce, while the issue is investigated.

Sorry for the whiplash.