### PR TITLE
moving ng-class off of top level of directive

### DIFF
--- a/assets/js/fsPerson/templates/fsPersonPortrait.html
+++ b/assets/js/fsPerson/templates/fsPersonPortrait.html
@@ -1,10 +1,10 @@
-<div class="fs-person-portrait" data-ng-class="{'fs-person--person-card': options.personCard}">
-  <div class="fs-person-portrait__container">
+<div class="fs-person-portrait">
+  <div class="fs-person-portrait__container" data-ng-class="{'fs-person--person-card': options.personCard}">
     <div class="fs-person-portrait__portrait fs-couple__connector fs-icon-before fs-icon-{{portraitSize}}-{{gender}}">
       <img class="fs-person-portrait__image" data-ng-if="person.portraitUrl" data-ng-src="{{person.portraitUrl}}" data-test="portrait">
     </div>
   </div>
-  <div class="fs-person-portrait__gender-wrapper">
+  <div class="fs-person-portrait__gender-wrapper" data-ng-class="{'fs-person--person-card': options.personCard}">
     <fs-person-gender data-person="person" data-options="options"></fs-person-gender>
   </div>
 </div>


### PR DESCRIPTION
Apparently it is common in tree to add an ng-class attribute to the element that calls this directive in this manner:
`<fs-person-portrait data-ng-class="{'empty-person': couple.wife.isEmpty}">` 
Unfortunately, since replace is set to true, the merge of ng-class from inside the directive and the calling element doesn't work (see: https://github.com/angular/angular.js/issues/5695).  There are two ways to fix this. Either set replace to false (which could have unexpected behaviors for the acceptance tests on tree) or move the fs-person--person-card class down a level in the directive. The latter is what I have done in this PR, but I'm open to the other way if we think it's a better way.