### PR TITLE
OFT-66737 - Bug fix for nameWrapper not gating based on name.

### DIFF
--- a/assets/js/fsPerson/ngFsPerson/ngFsPersonVitals.directive.js
+++ b/assets/js/fsPerson/ngFsPerson/ngFsPersonVitals.directive.js
@@ -41,7 +41,7 @@ angular.module('ngFsModules')
         }
 
         // Add name-wrapper functionality
-        if (scope.person && scope.person.id && scope.options.nameWrapper) {
+        if (scope.person && scope.person.name && scope.options.nameWrapper) {
           $timeout(function(){
             var pidWrapper = element.find('[data-fs-add-wrapper-if][title]');
             var name = element.find('.fs-person-vitals__name')[0];


### PR DESCRIPTION
This bug resulted in "[Unknown Name]" showing in the person card because when it is called on the Relationship, Change Log and List/Watch pages, only the person's id is passed in. Gating based on name instead of id will ensure that nameWrapper only occurs when the name is present (i.e. after the request for data in these cases).

Note: We were already doing this for the non-angular person renderer (i.e. Person Summary).

@straker Please review.