### PR TITLE
Ensuring that names on fs-person-vitals will update when changed

### DIFF
--- a/assets/js/fsPerson/ngFsPerson/ngFsPersonVitals.directive.js
+++ b/assets/js/fsPerson/ngFsPerson/ngFsPersonVitals.directive.js
@@ -40,30 +40,6 @@ angular.module('ngFsModules')
           scope.openPersonCardCmd = "openPersonCard";
         }
 
-        // Add name-wrapper functionality
-        if (scope.person && scope.person.name && scope.options.nameWrapper) {
-          $timeout(function(){
-            var pidWrapper = element.find('[data-fs-add-wrapper-if][title]');
-            var name = element.find('.fs-person-vitals__name')[0];
-            var wrap = '<' + scope.options.nameWrapper + ' class="fs-person-vitals__name ' + scope.nameConclusionStyle + '" style="padding:0; margin:0;">' + name.innerHTML + '</' + scope.options.nameWrapper + '>';
-
-            if (pidWrapper.find('.fs-person-vitals__name')[0]) {
-              pidWrapper.find('.fs-person-vitals__name').replaceWith($(wrap));
-            } else {
-              //Hack for race condition. About 10% of the time, the name will be placed as a sibling to the pid wrapper instead of as a child to it. This is to help remedy that.
-              setTimeout(function(){
-                // Check again for the name
-                if (pidWrapper.find('.fs-person-vitals__name')[0]) {
-                  pidWrapper.find('.fs-person-vitals__name').replaceWith($(wrap));
-                } else {
-                  // Manually move the name into the wrapper
-                  name.parentNode.removeChild(name);
-                  pidWrapper[0].insertBefore($(wrap)[0], pidWrapper.children()[0])
-                }
-              }, 100);
-            }
-          },0);
-        }
       });
     }
   };

--- a/assets/js/fsPerson/templates/fsPersonVitals.html
+++ b/assets/js/fsPerson/templates/fsPersonVitals.html
@@ -1,13 +1,15 @@
 <div class="fs-person-vitals">
   <div data-fs-add-wrapper-if="person.id" title="{{title}}">
-    <div class="fs-person-vitals__name" data-ng-class="nameConclusionStyle">
-      <a data-ng-href="{{personPageLink}}" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard || options.openPersonPage" data-cmd="{{openPersonCardCmd}}" data-cmd-data="{{openPersonCardData}}">
-        <span class="fs-person-vitals__name--split" data-ng-if="person.nameConclusion.details.nameForms">
-          <span class="fs-person-vitals__name-given" data-ng-bind-html="givenPart" data-test="given-name"></span><br>
-          <span class="fs-person-vitals__name-family" data-ng-bind-html="familyPart" data-test="family-name"></span>
-        </span>
-        <span class="fs-person-vitals__name-full" data-ng-bind-html="name" data-test="full-name"></span>
-      </a>
+    <div class="fs-person-vitals__name" data-ng-class="nameConclusionStyle" data-fs-add-wrapper-if="!options.nameWrapper">
+      <h3 class="fs-person-vitals__name" data-ng-class="nameConclusionStyle" data-fs-add-wrapper-if="options.nameWrapper" style="padding:0; margin:0;">
+        <a data-ng-href="{{personPageLink}}" class="fs-person-vitals__link" data-fs-add-wrapper-if="options.openPersonCard || options.openPersonPage" data-cmd="{{openPersonCardCmd}}" data-cmd-data="{{openPersonCardData}}">
+          <span class="fs-person-vitals__name--split" data-ng-if="person.nameConclusion.details.nameForms">
+            <span class="fs-person-vitals__name-given" data-ng-bind-html="givenPart" data-test="given-name"></span><br>
+            <span class="fs-person-vitals__name-family" data-ng-bind-html="familyPart" data-test="family-name"></span>
+          </span>
+          <span class="fs-person-vitals__name-full" data-ng-bind-html="name" data-test="full-name"></span>
+        </a>
+      </h3>
     </div>
     <div class="fs-person-vitals__fs-person-details">
       <div class="fs-person-details__container">

--- a/assets/js/fsPerson/test/personRendererTest.js
+++ b/assets/js/fsPerson/test/personRendererTest.js
@@ -382,7 +382,6 @@ describe('fsPerson', function () {
       if (isAngularTest) {
         $scope.person = person;
         compileDirective('<fs-person-vitals data-person="person" bindonce="person" data-config="{nameWrapper: \'h3\'}"></fs-person-vitals>');
-        $timeout.flush();
       }
       else {
         $template = fsModules.fsPersonVitals(person, {nameWrapper: "h3"});


### PR DESCRIPTION
Changing from using special name-wrapper functionality to using fs-add-wrapper-if.

This does disallow us from using any wrapper except h3, but that is currently our only use case.