### PR TITLE
TW-1033 - HTML-decode '&amp;' to '&' in portraitUrl (bifrost)

### DIFF
--- a/assets/modules/fsPerson/ngFsPerson/ngFsPersonPortrait.directive.js
+++ b/assets/modules/fsPerson/ngFsPerson/ngFsPersonPortrait.directive.js
@@ -20,6 +20,11 @@ angular.module('ngFsModules')
 
       scope.$watch('person', function fsPersonPortraitWatchAction() {
         scope = fsPersonPortraitViewModel(scope);
+        // TW-1033 - In tree-port-pedigree's portraitService.js, FST.htmlEncodeObjectsStrings
+        // is HTML-encoding ampersands in portraitUrl. This hack replaces '&amp;' with '&'
+        if(scope.person.portraitUrl) {
+          scope.person.portraitUrl = scope.person.portraitUrl.replace(/&amp;/g, '&');
+        }
       });
     },
     compile: function(tElement, tAttrs) {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-modules",
   "main": "app.js",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "moduleType": [
     "globals",
     "node"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-modules",
   "description": "JavaScript and Angular modules that work in conjunction with fs-webdev/fs-styles for the FamilySearch.org website.",
-  "version": "2.4.2",
+  "version": "3.0.1",
   "homepage": "https://github.com/fs-webdev/fs-modules",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In `tree-port-pedigree's` portraitService.js, `FST.htmlEncodeObjectsStrings` is HTML-encoding ampersands in portraitUrl and all other strings.  I wasn't sure the ramifications of making the change in `tree-port-pedigree` to no longer call `FST.htmlEncodeObjectsStrings` on the data object.  Therefore, I isolated the change to just the `fs-person-portrait` directive that the displays the portrait.  

This merges code into the `bifrost` branch because `frontier-tree` is hard-pinned to that branch, there is another pull request to merge the changes into `master` 

* Replaces '&amp;' with '&'.  
* Updates the version to 3.0.1, since the last release was actually 3.0.0.