### PR TITLE
[TW-2280] Update Travis CI Configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ branches:
     - master
 # Cache bower dependencies for faster/network error-tolerant builds (provided cache invalidation occurs as expected)
 cache:
-  directories:
-  - components # bower packages
-  - node_modules # node packages
+  npm: false
+  directories: null
 dist: trusty
 language: node_js
 node_js:


### PR DESCRIPTION
This PR partially resolves [TW-2280](https://almtools.ldschurch.org/fhjira/browse/TW-2280).

- Update Slack integration because `ldschurch.slack.com` is now `familysearch.slack.com`
- Explicitly tell Travis not to cache NPM because as of July 2019 [they are cached by default](https://docs.travis-ci.com/user/caching/#npm-cache).