### PR TITLE
pin to master hf so the bower.json and package.json hf versions stay …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "angular-animate": "~1.2.32",
     "angular-mocks": "~1.2.32",
     "angular-sanitize": "~1.2.32",
-    "hf": "fs-webdev/hf#~2.18.4",
+    "hf": "fs-webdev/hf#master",
     "inject": "^0.7.2",
     "jquery-ui": "jqueryui#1.10.4"
   },


### PR DESCRIPTION
…in sync (getting out of sync breaks builds)

This change fixes the (currently broken) search-bifrost build.
See discussion in hf-triage in slack.